### PR TITLE
fix: updated pandas dependency to support Python3.8.5 + pandas 0.25.3 environments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setuptools.setup(
     package_dir={'': 'src'},
     packages=setuptools.find_packages('src'),
     install_requires=[
-        'pandas~=0.24.0',
+        'pandas>=0.24.0,<1.0.0',
         'nltk>=3.4.0',
         'textblob>=0.15.3',
         'scikit-learn>=0.21.3',


### PR DESCRIPTION
previous pandas~=0.2.4 would not install/compile in Python3.8.5 environments.  We're now using min/max dependency 'pandas>=0.24.0,<1.0.0' which will install 0.25.3 which is supported in Python 3.8.5