### PR TITLE
fix: removed scipy dependency which caused an error during pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setuptools.setup(
         'pandas>=1.1.0',
         'nltk>=3.4.0',
         'textblob>=0.15.3',
-        'scipy>=1.3.0,<1.5.3',
+        # 'scipy>=1.3.0,<1.5.3',
         'scikit-learn>=0.21.3',
         'tqdm>=4.31.1',
         'ipywidgets>=7.4.2',


### PR DESCRIPTION
removed scipy from the list of dependant libraries as it is not needed any more