### PR TITLE
feat: add option to fill response_text with node options

### DIFF
--- a/notebooks/Dialog Flow Analysis Notebook.ipynb
+++ b/notebooks/Dialog Flow Analysis Notebook.ipynb
@@ -416,6 +416,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Set this to True if you need to fill response_text with node options for response_type == \"options\"\n",
+    "collect_options_response = False\n",
+    "\n",
+    "if collect_options_response:\n",
+    "    df_logs_canonical[\"response_text\"] = df_logs_canonical.apply(\n",
+    "    (\n",
+    "        lambda row: transformation.collect_option_response_text(workspace[\"dialog_nodes\"], row[\"nodes_visited\"]) \n",
+    "        if len(row[\"response_text\"]) == 0 else row[\"response_text\"]\n",
+    "    ), \n",
+    "    axis=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# the rest of the notebook runs on the df_logs_to_analyze object.  \n",
     "df_logs_to_analyze = df_logs_canonical.copy(deep=False)\n",
     "df_logs_to_analyze.head(2)"

--- a/src/conversation_analytics_toolkit/transformation.py
+++ b/src/conversation_analytics_toolkit/transformation.py
@@ -579,3 +579,23 @@ def _extract_dialog_node_name(dialog_nodes):
         else:
             nodes_dict[obj['dialog_node']] = (obj['dialog_node'],obj['type'])
     return nodes_dict
+
+def collect_option_response_text(dialog_nodes, target_nodes):
+    """
+    Replace empty response text with node options when response_type == "options"
+    """
+    response_text = []
+
+    for target in target_nodes:
+        for node in dialog_nodes:
+            if (
+                node.get("dialog_node", "") == target
+                and "output" in node
+                and "generic" in node["output"]
+            ):
+                for item in node["output"]["generic"]:
+                    if item["response_type"] == "option":
+                        for option in item["options"]:
+                            response_text.append(option["value"]["input"]["text"])
+
+    return response_text


### PR DESCRIPTION
This is for cases where `response_type == "options"` and `respnse_text` is empty in the dataframe. In this case, the options text can be pulled from the workspace.